### PR TITLE
Enable GPT replies to direct messages

### DIFF
--- a/cogs/commands.py
+++ b/cogs/commands.py
@@ -1,13 +1,25 @@
 import discord
 from discord import app_commands
 from discord.ext import commands
-import os
 import datetime
 import random
 import json
 import asyncio
-from typing import Optional
+from typing import Any, Optional
 import requests  # For API calls
+
+from utils.gpt_client import (
+    GPT_API_KEY,
+    DEFAULT_SYSTEM_PROMPT,
+    gpt_is_configured,
+    get_openai_client,
+    request_chat_completion,
+)
+
+# -------------------------------
+# Environment configuration
+# -------------------------------
+openai_client: Optional[Any] = get_openai_client()
 
 # -------------------------------
 # Helper for safe messaging
@@ -75,6 +87,34 @@ class Commands(commands.Cog):
         except Exception as e:
             await safe_send(interaction, content=f"Error retrieving news: {e}")
 
+    @app_commands.command(name='askgpt', description="Consult GPT for a thoughtful reply.")
+    @app_commands.describe(prompt="The query you would like me to relay to GPT.")
+    async def askgpt(self, interaction: discord.Interaction, prompt: str):
+        if not GPT_API_KEY or not gpt_is_configured() or not openai_client:
+            await safe_send(
+                interaction,
+                content="I regret to inform you that no GPT API key was configured."
+            )
+            return
+
+        try:
+            message = await request_chat_completion(
+                prompt,
+                system_prompt=DEFAULT_SYSTEM_PROMPT,
+            )
+            if not message:
+                message = "GPT returned no content, I'm afraid."
+
+            await safe_send(
+                interaction,
+                content=f"{interaction.user.mention}, GPT suggests:\n\n{message}"
+            )
+        except Exception as exc:
+            await safe_send(
+                interaction,
+                content=f"I encountered a difficulty consulting GPT: {exc}"
+            )
+
     @app_commands.command(name='commands', description="Display available commands.")
     async def commands_list(self, interaction: discord.Interaction):
         embed = discord.Embed(
@@ -87,7 +127,13 @@ class Commands(commands.Cog):
         embed.add_field(name="/companioncube", value="Assign a virtual Companion Cube.", inline=True)
         embed.add_field(name="/toxin", value="Deliver a gentle reprimand.", inline=True)
         embed.add_field(name="/science", value="Fetch the latest science news.", inline=True)
+        embed.add_field(name="/askgpt", value="Consult GPT for a thoughtful reply.", inline=True)
         embed.add_field(name="/commands", value="Display this command list.", inline=True)
+        embed.add_field(
+            name="Chat with me",
+            value="Mention me or send a DM and I will consult GPT on your behalf.",
+            inline=False,
+        )
         embed.set_footer(text="At your service.")
         await safe_send(interaction, embed=embed)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 pillow
 yt-dlp
 pytz
+openai

--- a/utils/gpt_client.py
+++ b/utils/gpt_client.py
@@ -1,0 +1,65 @@
+"""Utilities for interacting with the configured GPT provider."""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from openai import AsyncOpenAI
+
+GPT_API_KEY = os.getenv("GPT_API_KEY")
+DEFAULT_GPT_MODEL = os.getenv("GPT_MODEL", "gpt-3.5-turbo")
+DEFAULT_SYSTEM_PROMPT = os.getenv(
+    "GPT_SYSTEM_PROMPT",
+    "You are a polite and helpful assistant.",
+)
+
+_openai_client: Optional[AsyncOpenAI] = (
+    AsyncOpenAI(api_key=GPT_API_KEY) if GPT_API_KEY else None
+)
+
+
+def get_openai_client() -> Optional[AsyncOpenAI]:
+    """Return the shared AsyncOpenAI client if it is configured."""
+    return _openai_client
+
+
+def gpt_is_configured() -> bool:
+    """Indicate whether a GPT API key was supplied."""
+    return _openai_client is not None
+
+
+async def request_chat_completion(
+    prompt: str,
+    *,
+    system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+    model: Optional[str] = None,
+) -> str:
+    """Request a chat completion for the provided prompt.
+
+    Args:
+        prompt: The user prompt to relay to GPT.
+        system_prompt: Optional system prompt to prime the model.
+        model: Override the default model name, if desired.
+
+    Returns:
+        The trimmed content of the first message choice.
+
+    Raises:
+        RuntimeError: If no API key is configured.
+        Any exception surfaced by the OpenAI SDK when making the request.
+    """
+
+    client = get_openai_client()
+    if client is None:
+        raise RuntimeError("No GPT API key configured.")
+
+    response = await client.chat.completions.create(
+        model=model or DEFAULT_GPT_MODEL,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+    )
+
+    message = response.choices[0].message.content if response.choices else ""
+    return message.strip()


### PR DESCRIPTION
## Summary
- centralize GPT client setup in a reusable utility module
- update the /askgpt command to use the shared helper and document conversational access in the help embed
- respond to DMs and mentions by forwarding prompts to GPT and relaying the answer

## Testing
- python -m compileall cogs/commands.py cogs/events.py utils/gpt_client.py

------
https://chatgpt.com/codex/tasks/task_e_68d9a91f0a5483218b431252730b0e98